### PR TITLE
Fix for MD generation

### DIFF
--- a/steamcmd_appid_servers.sh
+++ b/steamcmd_appid_servers.sh
@@ -8,10 +8,10 @@
 rootdir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 echo "Creating steamcmd_appid_servers.json"
-curl https://api.steampowered.com/ISteamApps/GetAppList/v2/ | jq -c '.applist.apps[] | select(.name | contains("server","Server"))' > steamcmd_appid_servers.json
+curl https://api.steampowered.com/ISteamApps/GetAppList/v2/ | jq -c '[.applist.apps[] | select(.name | contains("server","Server"))]' > steamcmd_appid_servers.json
 echo "Creating steamcmd_appid_servers.csv"
-cat steamcmd_appid_servers.json | jq -r '[.appid, .name] | @csv' > steamcmd_appid_servers.csv
+cat steamcmd_appid_servers.json | jq -r '.[] | [.appid, .name] | @csv' > steamcmd_appid_servers.csv
 echo "Creating steamcmd_appid_servers.md"
-cat steamcmd_appid_servers.json | jq '.[]' | md-table > steamcmd_appid_servers.md
+cat steamcmd_appid_servers.json | md-table > steamcmd_appid_servers.md
 echo "exit"
 exit


### PR DESCRIPTION
Change the JSON output to be an array of elements. 
Change the CSV parser to read each entity in turn, pipe to find the elements and output to CSV
Removed jq from MD generation - the NPM package will parse the json array