### PR TITLE
Remove -c flag from jq

### DIFF
--- a/steamcmd_appid_servers.sh
+++ b/steamcmd_appid_servers.sh
@@ -8,7 +8,7 @@
 rootdir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 echo "Creating steamcmd_appid_servers.json"
-curl https://api.steampowered.com/ISteamApps/GetAppList/v2/ | jq -c '[.applist.apps[] | select(.name | contains("server","Server"))]' > steamcmd_appid_servers.json
+curl https://api.steampowered.com/ISteamApps/GetAppList/v2/ | jq '[.applist.apps[] | select(.name | contains("server","Server"))]' > steamcmd_appid_servers.json
 echo "Creating steamcmd_appid_servers.csv"
 cat steamcmd_appid_servers.json | jq -r '.[] | [.appid, .name] | @csv' > steamcmd_appid_servers.csv
 echo "Creating steamcmd_appid_servers.md"


### PR DESCRIPTION
-c flag compacts the output. Removing this flag produces pretty-print

Fixes #3 